### PR TITLE
Skip linkerd checks for Kubernetes >=1.17.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Wrapper helm chart for MetaKube LinkerD addon
 name: linkerd-helm
-version: 0.1.5
+version: 0.1.6

--- a/templates/scripts.yaml
+++ b/templates/scripts.yaml
@@ -22,15 +22,19 @@ data:
 
     if kubectl get namespace linkerd > /dev/null 2>&1;then
       echo "linkerd namespace already exists . . ."
+    {{ if and (eq .Capabilities.KubeVersion.Major 1) (lt .Capabilities.KubeVersion.Minor 17) }}
       linkerd check
+    {{ end }}
     {{ if .Values.highAvailability }}
       linkerd upgrade --ha | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -
     {{ else }}
       linkerd upgrade | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -
     {{ end }}
     else
+    {{ if and (eq .Capabilities.KubeVersion.Major 1) (lt .Capabilities.KubeVersion.Minor 17) }}
       # linkerd preflight checks
       linkerd check --pre
+    {{ end }}
       # Install linkerd
     {{ if .Values.highAvailability }}
       linkerd install --ha | kubectl apply -f -


### PR DESCRIPTION
Due to https://github.com/kubernetes/kubernetes/pull/84351 we have to
skip the checks until https://github.com/linkerd/linkerd2/pull/3947 is
released by upstream.